### PR TITLE
Fix module name, align build to `maven-compile-plugin` guidelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,13 +106,12 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.11.2</version>
           <configuration>
-            <!-- https://bugs.openjdk.org/browse/JDK-8274639 -->
-            <additionalOptions>--link-modularity-mismatch=info</additionalOptions>
             <failOnWarnings>true</failOnWarnings>
             <links>
               <link>https://javadoc.io/static/com.google.jimfs/jimfs/${jimfs.version}/</link>
               <link>https://junit.org/junit5/docs/${junit-jupiter.version}/api/</link>
             </links>
+            <release>9</release>
           </configuration>
         </plugin>
         <plugin>
@@ -191,16 +190,20 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>
-            <id>java-9</id>
+            <id>default-compile</id>
+            <configuration>
+              <release>9</release>
+            </configuration>
+          </execution>
+          <execution>
+            <id>java-8</id>
             <goals>
               <goal>compile</goal>
             </goals>
             <configuration>
-              <compileSourceRoots>
-                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
-              </compileSourceRoots>
-              <multiReleaseOutput>true</multiReleaseOutput>
-              <release>9</release>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/io/github/scordio/jimfs/junit/jupiter/package-info.java
+++ b/src/main/java/io/github/scordio/jimfs/junit/jupiter/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2025 Stefano Cordio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JUnit Jupiter {@link org.junit.jupiter.api.io.TempDir} extension based on {@link
+ * com.google.common.jimfs.Jimfs}.
+ */
+package io.github.scordio.jimfs.junit.jupiter;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2025 Stefano Cordio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JUnit Jupiter {@link org.junit.jupiter.api.io.TempDir} extension based on {@link
+ * com.google.common.jimfs.Jimfs}.
+ */
+@SuppressWarnings("requires-transitive-automatic")
+module io.github.scordio.jimfs.junit.jupiter {
+  requires transitive com.google.common.jimfs;
+  requires org.junit.jupiter.api;
+
+  exports io.github.scordio.jimfs.junit.jupiter;
+}

--- a/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JimfsTempDirFactoryTests.java
+++ b/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JimfsTempDirFactoryTests.java
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.scordio.jimfs.junit.jupiter;
+package io.github.scordio.jimfs.junit.jupiter.tests;
 
-import static io.github.scordio.jimfs.junit.jupiter.JupiterEngineTestKit.executeTests;
-import static io.github.scordio.jimfs.junit.jupiter.JupiterEngineTestKit.executeTestsForClass;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.osXFileSystem;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.unixFileSystem;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.windowsFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.JupiterEngineTestKit.executeTests;
+import static io.github.scordio.jimfs.junit.jupiter.tests.JupiterEngineTestKit.executeTestsForClass;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.osXFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.unixFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.windowsFileSystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.condition.OS.MAC;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import io.github.scordio.jimfs.junit.jupiter.JimfsTempDir;
+import io.github.scordio.jimfs.junit.jupiter.JimfsTempDirFactory;
 import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JimfsTempDirTests.java
+++ b/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JimfsTempDirTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.scordio.jimfs.junit.jupiter;
+package io.github.scordio.jimfs.junit.jupiter.tests;
 
 import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.Configuration.DEFAULT;
 import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.Configuration.FOR_CURRENT_PLATFORM;
@@ -21,16 +21,17 @@ import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.Configuration.O
 import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.Configuration.UNIX;
 import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.Configuration.WINDOWS;
 import static io.github.scordio.jimfs.junit.jupiter.JimfsTempDir.DEFAULT_CONFIGURATION_PARAMETER_NAME;
-import static io.github.scordio.jimfs.junit.jupiter.JupiterEngineTestKit.executeTests;
-import static io.github.scordio.jimfs.junit.jupiter.JupiterEngineTestKit.executeTestsForClass;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.osXFileSystem;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.unixFileSystem;
-import static io.github.scordio.jimfs.junit.jupiter.Requirements.windowsFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.JupiterEngineTestKit.executeTests;
+import static io.github.scordio.jimfs.junit.jupiter.tests.JupiterEngineTestKit.executeTestsForClass;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.osXFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.unixFileSystem;
+import static io.github.scordio.jimfs.junit.jupiter.tests.Requirements.windowsFileSystem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.condition.OS.MAC;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
+import io.github.scordio.jimfs.junit.jupiter.JimfsTempDir;
 import java.nio.file.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JupiterEngineTestKit.java
+++ b/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/JupiterEngineTestKit.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.scordio.jimfs.junit.jupiter;
+package io.github.scordio.jimfs.junit.jupiter.tests;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;

--- a/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/Requirements.java
+++ b/src/test/java/io/github/scordio/jimfs/junit/jupiter/tests/Requirements.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.scordio.jimfs.junit.jupiter;
+package io.github.scordio.jimfs.junit.jupiter.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -13,15 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * JUnit Jupiter {@link org.junit.jupiter.api.io.TempDir} extension based on {@link
- * com.google.common.jimfs.Jimfs}.
- */
-@SuppressWarnings("requires-transitive-automatic")
-module jimfs.junit.jupiter {
-  requires transitive com.google.common.jimfs;
-  requires org.junit.jupiter.api;
-
-  exports io.github.scordio.jimfs.junit.jupiter;
+open module io.github.scordio.jimfs.junit.jupiter.tests {
+  requires io.github.scordio.jimfs.junit.jupiter;
+  requires org.assertj.core;
+  requires org.junit.jupiter.params;
+  requires org.junit.platform.testkit;
 }


### PR DESCRIPTION
This change also enables building modular Javadoc.

Fixes #17.